### PR TITLE
Add Christian's changes: Fix comment behavior and reset run machine button on failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Compatible with xTuringmachine files
 - Jonathan Bryan [jbryan74@vols.utk.edu]   
 - Josh Herman [jherman4@vols.utk.edu]   
 - Jahneulie Weste [wsv346@vols.utk.edu]
+- Christian Niehaus [cniehau1@vols.utk.edu]
 
 ## Pre-requisites
 - Java 9 or greater

--- a/src/main/java/Editor.java
+++ b/src/main/java/Editor.java
@@ -817,6 +817,7 @@ class Editor {
 			//                       |_|
 
 			editorSpace.removeEventFilter(MouseEvent.MOUSE_MOVED, MoveEvent);
+			editorSpace.setCursor(Cursor.DEFAULT);
 			if(currentHandler != null)
 				editorSpace.removeEventHandler(MouseEvent.MOUSE_CLICKED, currentHandler);
 			if(pressHandler != null)
@@ -936,9 +937,12 @@ class Editor {
 				for (Path p : currentMachine.getPaths())
 					p.setTextFillColor(Color.DARKRED);
 
-				for (TextArea ta: currentMachine.getComments()){
+				for (int i = 0; i < currentMachine.getComments().size(); i++){
+					TextArea ta = currentMachine.getComments().get(i);
 					if(ta.getLength() == 0){
 						editorSpace.getChildren().remove(ta);
+						currentMachine.getComments().remove(ta);
+						i--;
 					}
 				}
 

--- a/src/main/java/Machine.java
+++ b/src/main/java/Machine.java
@@ -121,7 +121,7 @@ class Machine {
 	public String toString(){
 		//System.out.println("I'm in toString");
 		StringBuilder ret = new StringBuilder();
-		ret.append(String.format("// Save File for STEM\n// Version %.2f\n\n", 1.1)); //Bumped to v 1.1 for adding comments to SaveLoad
+		ret.append(String.format("// Save File for STEM\n// Version %.2f\n\n", 1.11)); //Bumped to v 1.11 for adding comments to SaveLoad
 		ret.append("// State Format: name x y start accept\n");
 		ret.append("STATES:\n");
 
@@ -134,7 +134,7 @@ class Machine {
 		}
 		ret.append("\n");
 
-		ret.append("// Transition format: fromStateId toStateId readCHar writeChar moveDirection\n");
+		ret.append("// Transition format: fromStateId toStateId readChar writeChar moveDirection\n");
 		ret.append("// The Character '~' is the catchall character\n");
 		ret.append("TRANSITION:\n");
 
@@ -159,7 +159,7 @@ class Machine {
 		ret.append("// Comment format: text:x:y\n");
 		ret.append("COMMENTS:\n");
 		for (TextArea ta: comments){
-			ret.append(String.format("%s:%f:%f\n", ta.getText(), ta.getLayoutX(), ta.getLayoutY()));
+			ret.append(String.format("%s\n:%f:%f\n", ta.getText().replace(":", "\\:"), ta.getLayoutX(), ta.getLayoutY()));
 		}
 		ret.append("// Comments End\n");
 

--- a/src/main/java/SaveLoad.java
+++ b/src/main/java/SaveLoad.java
@@ -311,6 +311,7 @@ public class SaveLoad {
                     Scanner colGrabber = new Scanner(k);
                     Color nucolor = new Color(colGrabber.nextDouble(), colGrabber.nextDouble(), colGrabber.nextDouble(), colGrabber.nextDouble());
                     newState.setColor(nucolor);
+                    colGrabber.close();
                 }
 
                 // Add state to machine
@@ -380,7 +381,7 @@ public class SaveLoad {
 
         curLine = br.readLine();
 
-        // IF VERSION 1.1
+        // IF VERSION with comments
         if(version > 1)
         {
           // Read until beginning of COMMENTS
@@ -393,15 +394,28 @@ public class SaveLoad {
             TextArea ta = new TextArea();
             ta.setFont(Font.font("Verdana", 20));
             ta.setStyle("-fx-background-color: rgba(255,255,255,0.4)");
-            //parse string till double is found. first double is x, second is y
+            //parse string till ':' is found. first double is x, second is y
             String text = "";
-            while(curLine.indexOf(":") == -1)
-            {
-              text = text + curLine + "\n";
-              curLine = br.readLine();
+            String[] line = null;
+            // check which version we are reading
+            // if the file is in the older verison, then we
+            // can just read it in with the old way, and when the user
+            // saves again, the new format will be used
+            if (version >= 1.11) {
+              while (curLine.indexOf(":") != 0) {
+                text = text + curLine.replace("\\:", ":") + "\n";
+                curLine = br.readLine();
+              }
+              line = curLine.split(":");
+              text = text.substring(0, text.length() - 1); // remove the last newline
+            } else { // read in with the old way
+              while (curLine.indexOf(":") == -1) {
+                text = text + curLine + "\n";
+                curLine = br.readLine();
+              }
+              line = curLine.split(":");
+              text = text + line[0];
             }
-            String line[] = curLine.split(":");
-            text = text + line[0];
             double x = Double.parseDouble(line[1]);
             double y = Double.parseDouble(line[2]);
 

--- a/src/main/java/Tester.java
+++ b/src/main/java/Tester.java
@@ -119,6 +119,7 @@ public class Tester {
 
         // Main body
 
+        finalState = currentState; 
         Transition next = this.nextTransition(currentState, m.getTape());
         while(next != null && cont != false) {
 


### PR DESCRIPTION
Bugs Identified & Fixed: 
- If you have a colon in a comment, your save file will be unable to load
- If you reject before performing a transition, the simulator will throw an error, the machine will stop, and the Stop Machine button will remain and do nothing
- When a comment is deleted, it is not removed from the machine, and so is still present in the save file and appears on a reload

## Summary by Sourcery

Fix critical issues with comment handling, save file loading, and machine state management in the STEM simulator

Bug Fixes:
- Resolve issues with saving and loading files when comments contain colons by implementing escape character handling
- Fix simulator errors when rejecting transitions before performing them
- Ensure comments are properly removed from the machine when deleted

Enhancements:
- Improve save file version handling to support backward compatibility
- Enhance error handling and state management during machine runs

Chores:
- Update project version to 1.11
- Add Christian Niehaus to the contributors list